### PR TITLE
Add double slashes along with exclamation mark for anouncements

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -86,7 +86,7 @@ app.post "/webhook", (req, res) ->
   adminNick = req.body.user_name
 
   # If the message is not meant to be sent to jinora users, but it is a command meant to be interpreted by jinora
-  isCommand = (req.body.text[0] == "!")
+  isCommand = req.body.text.startsWith("!") || req.body.text.startsWith("\\") 
   if isCommand
     commandText = message.substr(1)
     interpretCommand(commandText,adminNick)


### PR DESCRIPTION
Announcement for channel can now be made using double slashes (`\\`) along with existing character (`!`).
> **NOTE:** These changes are note tested.