### PR TITLE
Replace slack-utils with slack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 tests/*.js
 bower_components/
 reserved_nicks
+
+.idea

--- a/announcements.coffee
+++ b/announcements.coffee
@@ -31,7 +31,7 @@ module.exports = (ioObject, slackObject) ->
     req.io.emit 'announcement:data', announcement
 
   showHelp : ->
-      slack.postMessage helpText, process.env.SLACK_CHANNEL, "Jinora"
+    slack.postMessage helpText, process.env.SLACK_CHANNEL, "Jinora"
 
     interpret : (message, adminNick) ->
       index = message.indexOf(" ")

--- a/app.coffee
+++ b/app.coffee
@@ -8,12 +8,13 @@ session = require('express-session')
 fs = require('fs')
 path = require('path')
 CBuffer = require('CBuffer');
-slack = require('slack-utils/api')(process.env.API_TOKEN, process.env.INCOMING_HOOK_URL)
-presence = require('./presence.coffee')
+slack = require('slack')
+slack_utils = require('./slack_utils')(process.env.API_TOKEN, process.env.INCOMING_HOOK_URL)
+presence = require('./presence.coffee')(process.env.API_TOKEN)
 rate_limit = require('./rate_limit.coffee')
 app = express().http().io()
-announcementHandler = require('./announcements.coffee')(app.io, slack)
-userInfoHandler = require('./userinfo.coffee')(app.io, slack)
+announcementHandler = require('./announcements.coffee')(app.io, slack_utils)
+userInfoHandler = require('./userinfo.coffee')(app.io, slack_utils)
 showdown = require('showdown')
 showdownHtmlEscape = require('showdown-htmlescape')
 sanitizeHtml = require('sanitize-html')
@@ -24,7 +25,7 @@ converter = new showdown.Converter
   openLinksInNewWindow: true
   strikethrough: true
 
-sanitizerOptions = 
+sanitizerOptions =
   allowedTags: ['b', 'i', 'em', 'strong', 'a', 'strike', 'del', 'code']
   allowedAttributes:
     'a': ['href', 'target']
@@ -35,7 +36,7 @@ sanitizeMessage = (msg) ->
   sanitizeHtml converter.makeHtml(msg), sanitizerOptions
 
 if !!process.env.RESERVED_NICKS_URL
-  userVerifier = require('./user.coffee')(slack)
+  userVerifier = require('./user.coffee')(slack_utils)
 else
   console.error "WARNING: banning won't work as RESERVED_NICKS_URL is not provided"
 
@@ -57,16 +58,16 @@ app.use express.bodyParser()
 
 app.set('trust proxy', 1);
 
-sessionConfig = 
-  secret: process.env.SESSION_SECRET 
+sessionConfig =
+  secret: process.env.SESSION_SECRET
   key: 'connect.sid'
   cookie:
     proxy: process.env.NODE_ENV == 'production',
     sameSite: "none"
     secure: process.env.NODE_ENV == 'production'
     resave: true
-    
-    
+
+
 app.use session sessionConfig
 app.use express.static __dirname + '/public'
 
@@ -85,7 +86,7 @@ interpretCommand = (commandText, adminNick) ->
       userVerifier.interpret commandText, adminNick
     else
       errorText = "Banning feature is not configured. Add RESERVED_NICKS_URL to .env file."
-      slack.postMessage errorText, process.env.SLACK_CHANNEL, "Jinora"
+      slack_utils.postMessage errorText, process.env.SLACK_CHANNEL, "Jinora"
   else if (firstWord in announcementCommands)
     announcementHandler.interpret commandText, adminNick
   else if (firstWord in userInfoCommands)
@@ -99,7 +100,7 @@ interpretCommand = (commandText, adminNick) ->
         text += "_Sample commands:_\n"
         text += "\t`!connectnotify on` for turning on user connect notifications.\n"
         text += "\t`!connectnotify off` for turning off user connect notifications.\n"
-      slack.postMessage text, process.env.SLACK_CHANNEL, 'Jinora'
+      slack_utils.postMessage text, process.env.SLACK_CHANNEL, 'Jinora'
     else
       userInfoHandler.interpret commandText
 
@@ -111,7 +112,7 @@ interpretCommand = (commandText, adminNick) ->
         messages.pop()
   else if firstWord is "users"
     msg = userInfoHandler.getOnlineUsers().join ', '
-    slack.postMessage msg, process.env.SLACK_CHANNEL, 'Jinora'
+    slack_utils.postMessage msg, process.env.SLACK_CHANNEL, 'Jinora'
   else if firstWord is "help"
     announcementHandler.showHelp()
 
@@ -123,23 +124,23 @@ app.post "/webhook", (req, res) ->
   # Prevents us from falling into a loop
   return res.json {} if req.body.user_id == 'USLACKBOT'
 
-  message = slack.parseMessage(req.body.text)
+  message = slack_utils.parseMessage(req.body.text)
   adminNick = req.body.user_name
 
   # If the message is not meant to be sent to jinora users, but it is a command meant to be interpreted by jinora
   isCommand = (req.body.text[0] == "!")
   if isCommand
     commandText = message.substr(1)
-    interpretCommand(commandText,adminNick)
+    interpretCommand(commandText, adminNick)
     res.send ""
     return
 
-  if slack.userInfoById(req.body.user_id)
-    profile = slack.userInfoById(req.body.user_id)['profile']
+  if slack_utils.userInfoById(req.body.user_id)
+    profile = slack_utils.userInfoById(req.body.user_id)['profile']
     avatar = profile['image_72']
     avatar192 = profile['image_192']
     if process.env.ADMIN_NICK == "full"
-      adminNick = slack.userInfoById(req.body.user_id)['profile']['real_name']
+      adminNick = slack_utils.userInfoById(req.body.user_id)['profile']['real_name']
   else
     avatar = "images/default_admin.png"
 
@@ -165,7 +166,6 @@ app.post "/webhook", (req, res) ->
   res.send ""
 
 
-
 # Broadcast the chat message to all connected clients,
 # including the one who made the request
 # also send it to slack
@@ -175,13 +175,16 @@ app.io.route 'chat:msg', (req)->
   return if typeof req.data.message != "string"
 
   delete req.data.invalidNick
-  req.data.admin = 0    # Indicates that the message is not sent by a team member
-  req.data.online = 0   # Online status of end user is not tracked, always set to 0
-  req.data.timestamp = (new Date).toISOString()   # Current Time
+  req.data.admin = 0 # Indicates that the message is not sent by a team member
+  req.data.online = 0 # Online status of end user is not tracked, always set to 0
+  req.data.timestamp = (new Date).toISOString() # Current Time
   if !req.data.avatar
     req.data.avatar = process.env.BASE_URL + "/images/default_user.png"
   # If RESERVED_NICKS_URL doesn't exist => userVerifier = ""
-  status = if req.cookies && !!(userVerifier) then userVerifier.verify req.data.nick, req.cookies['connect.sid'] else {"nick": true, "session": true}
+  status = if req.cookies && !!(userVerifier) then userVerifier.verify req.data.nick, req.cookies['connect.sid'] else {
+    "nick": true,
+    "session": true
+  }
   storeMsg = true
 
   slackChannel = process.env.SLACK_CHANNEL
@@ -194,28 +197,28 @@ app.io.route 'chat:msg', (req)->
     req.io.emit 'chat:msg', req.data
     return
 
-  # If the session is banned
+# If the session is banned
   else if !status['session']
     req.io.emit 'chat:msg', req.data
     slackChannel = process.env.BANNED_CHANNEL
     storeMsg = false
 
-  # If the message is private
+# If the message is private
   else if req.data.message[0] == '!'
     req.io.emit 'chat:msg', req.data
     storeMsg = false
 
   else
-    # Send the message to all jinora users
+# Send the message to all jinora users
     app.io.broadcast 'chat:msg', req.data
 
   # Send message to slack
   # If we were given a valid avatar
   if req.data.avatar
     icon = req.data.avatar
-    slack.postMessage originalMsg, slackChannel, req.data.nick, icon
+    slack_utils.postMessage originalMsg, slackChannel, req.data.nick, icon
   else
-    slack.postMessage originalMsg, slackChannel, req.data.nick
+    slack_utils.postMessage originalMsg, slackChannel, req.data.nick
 
   # Store message in memory
   if storeMsg
@@ -230,7 +233,7 @@ app.io.route 'chat:demand', (req)->
 app.io.route 'member:connect', (req)->
   userInfoHandler.addUser req
   if connectNotify == "on"
-    slack.postMessage "#{req.data.nick} entered channel", process.env.SLACK_CHANNEL, "Jinora"
+    slack_utils.postMessage "#{req.data.nick} entered channel", process.env.SLACK_CHANNEL, "Jinora"
 
 app.io.route 'presence:demand', (req)->
   req.io.emit 'presence:list', onlineMemberList
@@ -242,12 +245,12 @@ app.io.on 'connection', (socket)->
   socket.on 'disconnect', ()->
     nick = userInfoHandler.removeUser socket.id
     if connectNotify == "on"
-      slack.postMessage "#{nick} left channel", process.env.SLACK_CHANNEL, "Jinora"
+      slack_utils.postMessage "#{nick} left channel", process.env.SLACK_CHANNEL, "Jinora"
 
 presence.on 'change', ()->
   onlineMemberList = []
   for username in presence.online()
-    userInfo = slack.userInfoByName(username)
+    userInfo = slack_utils.userInfoByName(username)
     if userInfo
       if !!userInfo.is_bot    # Continue for loop in case is_bot is true. '!!'' take care of case when is_bot is undefined
         continue

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,26 +1,51 @@
 {
   "name": "jinora",
   "version": "2.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "CBuffer": {
       "version": "0.1.5",
-      "from": "CBuffer@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/CBuffer/-/CBuffer-0.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/CBuffer/-/CBuffer-0.1.5.tgz",
+      "integrity": "sha1-3yk7wEVCHg1N60dW1+kI9dJ2jrQ="
     },
     "bower": {
       "version": "1.8.2",
-      "from": "bower@>=1.3.12 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz"
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc="
     },
     "coffee-script": {
       "version": "1.12.7",
-      "from": "coffee-script@>=1.8.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "dotenv": {
       "version": "0.4.0",
-      "from": "dotenv@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz",
+      "integrity": "sha1-9vs1E2PC2SIHJFxzeALJq1rhSVo="
     },
     "express-session": {
       "version": "1.17.1",
@@ -39,427 +64,608 @@
     },
     "express.io": {
       "version": "1.1.13",
-      "from": "express.io@>=1.1.13 <2.0.0",
       "resolved": "https://registry.npmjs.org/express.io/-/express.io-1.1.13.tgz",
+      "integrity": "sha1-z9YKJFS9MzN9jM2Y7ZfD57z+XR8=",
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.4.0",
+        "express": "~3.4.0",
+        "socket.io": "~0.9.16",
+        "underscore": "1.4.3"
+      },
       "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
+        },
+        "coffee-script": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz",
+          "integrity": "sha1-XjvIqsJsAajie/EHcixWVfWtfTY="
+        },
         "express": {
           "version": "3.4.8",
-          "from": "express@>=3.4.0 <3.5.0",
           "resolved": "https://registry.npmjs.org/express/-/express-3.4.8.tgz",
+          "integrity": "sha1-qnqJht4HBTM39Lxe2aZFPZzI4uE=",
+          "requires": {
+            "buffer-crc32": "0.2.1",
+            "commander": "1.3.2",
+            "connect": "2.12.0",
+            "cookie": "0.1.0",
+            "cookie-signature": "1.0.1",
+            "debug": ">= 0.7.3 < 1",
+            "fresh": "0.2.0",
+            "merge-descriptors": "0.0.1",
+            "methods": "0.1.0",
+            "mkdirp": "0.3.5",
+            "range-parser": "0.0.4",
+            "send": "0.1.4"
+          },
           "dependencies": {
+            "buffer-crc32": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+              "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w="
+            },
+            "commander": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+              "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+              "requires": {
+                "keypress": "0.1.x"
+              },
+              "dependencies": {
+                "keypress": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+                  "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
+                }
+              }
+            },
             "connect": {
               "version": "2.12.0",
-              "from": "connect@2.12.0",
               "resolved": "https://registry.npmjs.org/connect/-/connect-2.12.0.tgz",
+              "integrity": "sha1-Mdj6DcrN8ZCNgivSkjvootKn7Zo=",
+              "requires": {
+                "batch": "0.5.0",
+                "buffer-crc32": "0.2.1",
+                "bytes": "0.2.1",
+                "cookie": "0.1.0",
+                "cookie-signature": "1.0.1",
+                "debug": ">= 0.7.3 < 1",
+                "fresh": "0.2.0",
+                "methods": "0.1.0",
+                "multiparty": "2.2.0",
+                "negotiator": "0.3.0",
+                "pause": "0.0.1",
+                "qs": "0.6.6",
+                "raw-body": "1.1.2",
+                "send": "0.1.4",
+                "uid2": "0.0.3"
+              },
               "dependencies": {
                 "batch": {
                   "version": "0.5.0",
-                  "from": "batch@0.5.0",
-                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
-                },
-                "qs": {
-                  "version": "0.6.6",
-                  "from": "qs@0.6.6",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
+                  "integrity": "sha1-/S4Fp6XWlrTbkxQBPihdj/NVfsM="
                 },
                 "bytes": {
                   "version": "0.2.1",
-                  "from": "bytes@0.2.1",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
-                },
-                "pause": {
-                  "version": "0.0.1",
-                  "from": "pause@0.0.1",
-                  "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
-                },
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "uid2@0.0.3",
-                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-                },
-                "raw-body": {
-                  "version": "1.1.2",
-                  "from": "raw-body@1.1.2",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz"
-                },
-                "negotiator": {
-                  "version": "0.3.0",
-                  "from": "negotiator@0.3.0",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
+                  "integrity": "sha1-VVsIq8sGP4l1kFMCUj5M1P/f3zE="
                 },
                 "multiparty": {
                   "version": "2.2.0",
-                  "from": "multiparty@2.2.0",
                   "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+                  "integrity": "sha1-pWfCrwAK0i3I8qZT2Rl4rh9TFvQ=",
+                  "requires": {
+                    "readable-stream": "~1.1.9",
+                    "stream-counter": "~0.2.0"
+                  },
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         }
                       }
                     },
                     "stream-counter": {
                       "version": "0.2.0",
-                      "from": "stream-counter@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+                      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
+                      "requires": {
+                        "readable-stream": "~1.1.8"
+                      }
                     }
                   }
+                },
+                "negotiator": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+                  "integrity": "sha1-cG1pLv7d9XTVfqn7GriaT6fuj2A="
+                },
+                "pause": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+                  "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+                },
+                "qs": {
+                  "version": "0.6.6",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+                  "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+                },
+                "raw-body": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz",
+                  "integrity": "sha1-x0swBN6l3v0WlhcRBqx0DsMdYr4=",
+                  "requires": {
+                    "bytes": "~0.2.1"
+                  }
+                },
+                "uid2": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+                  "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
                 }
               }
-            },
-            "commander": {
-              "version": "1.3.2",
-              "from": "commander@1.3.2",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
-              "dependencies": {
-                "keypress": {
-                  "version": "0.1.0",
-                  "from": "keypress@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
-                }
-              }
-            },
-            "range-parser": {
-              "version": "0.0.4",
-              "from": "range-parser@0.0.4",
-              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@0.3.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "cookie": {
               "version": "0.1.0",
-              "from": "cookie@0.1.0",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
-            },
-            "buffer-crc32": {
-              "version": "0.2.1",
-              "from": "buffer-crc32@0.2.1",
-              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-            },
-            "fresh": {
-              "version": "0.2.0",
-              "from": "fresh@0.2.0",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
-            },
-            "methods": {
-              "version": "0.1.0",
-              "from": "methods@0.1.0",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
-            },
-            "send": {
-              "version": "0.1.4",
-              "from": "send@0.1.4",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
-              "dependencies": {
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@>=1.2.9 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+              "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA="
             },
             "cookie-signature": {
               "version": "1.0.1",
-              "from": "cookie-signature@1.0.1",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
-            },
-            "merge-descriptors": {
-              "version": "0.0.1",
-              "from": "merge-descriptors@0.0.1",
-              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
+              "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss="
             },
             "debug": {
               "version": "0.8.1",
-              "from": "debug@>=0.7.3 <1.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+              "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA="
+            },
+            "fresh": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+              "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc="
+            },
+            "merge-descriptors": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.1.tgz",
+              "integrity": "sha1-L/CYDJJM+B0LXR+2ARd8uLtWwNA="
+            },
+            "methods": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
+              "integrity": "sha1-M11Cnu/SG3us8unJIqjSvRSjDk8="
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+            },
+            "range-parser": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+              "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs="
+            },
+            "send": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+              "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+              "requires": {
+                "debug": "*",
+                "fresh": "0.2.0",
+                "mime": "~1.2.9",
+                "range-parser": "0.0.4"
+              },
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+                }
+              }
             }
           }
         },
         "socket.io": {
           "version": "0.9.19",
-          "from": "socket.io@>=0.9.16 <0.10.0",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.19.tgz",
+          "integrity": "sha1-SQu1/Q3FTPAC7gTmf638Q7hIo48=",
+          "requires": {
+            "base64id": "0.1.0",
+            "policyfile": "0.0.4",
+            "redis": "0.7.3",
+            "socket.io-client": "0.9.16"
+          },
           "dependencies": {
+            "base64id": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+              "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8="
+            },
+            "policyfile": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
+              "integrity": "sha1-1rgurZiueeviKOLa9ZAzEeyYLk0="
+            },
+            "redis": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
+              "integrity": "sha1-7le3pE0l7BWU5ENl2BZfp9HUgRo=",
+              "optional": true
+            },
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "integrity": "sha1-TadRXF53MEHRtCOXBBW8xDDzX8Y=",
+              "requires": {
+                "active-x-obfuscator": "0.0.1",
+                "uglify-js": "1.2.5",
+                "ws": "0.4.x",
+                "xmlhttprequest": "1.4.2"
+              },
               "dependencies": {
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "integrity": "sha1-CJuJs3FF/x2ex0r2UwvlUmyuHxo=",
+                  "requires": {
+                    "zeparser": "0.0.5"
+                  },
+                  "dependencies": {
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
+                      "integrity": "sha1-A3JlYbwmjy5URPVMZlt/1KjAKeI="
+                    }
+                  }
+                },
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
+                  "integrity": "sha1-tULCx29477NLIAsgF3Y0Mw/3ArY="
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI=",
+                  "requires": {
+                    "commander": "~2.1.0",
+                    "nan": "~1.0.0",
+                    "options": ">=0.0.5",
+                    "tinycolor": "0.x"
+                  },
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+                      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
-                    },
-                    "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+                      "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+                      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
-                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
-                },
-                "active-x-obfuscator": {
-                  "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
-                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
-                  "dependencies": {
-                    "zeparser": {
-                      "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
-                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
+                  "integrity": "sha1-AUU6HZvtHo8XL2SVu/TIxCYyFQA="
                 }
               }
-            },
-            "policyfile": {
-              "version": "0.0.4",
-              "from": "policyfile@0.0.4",
-              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
-            },
-            "base64id": {
-              "version": "0.1.0",
-              "from": "base64id@0.1.0",
-              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-            },
-            "redis": {
-              "version": "0.7.3",
-              "from": "redis@0.7.3",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
-        "async": {
-          "version": "0.1.22",
-          "from": "async@0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
-        },
         "underscore": {
           "version": "1.4.3",
-          "from": "underscore@1.4.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.3.tgz"
-        },
-        "coffee-script": {
-          "version": "1.4.0",
-          "from": "coffee-script@1.4.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.3.tgz",
+          "integrity": "sha1-s9Cqoe502IbqTyZIAhpPitd57R0="
         }
       }
     },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "platform": {
       "version": "1.3.4",
-      "from": "platform@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
+      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0="
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
     },
     "request": {
       "version": "2.83.0",
-      "from": "request@>=2.65.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      },
       "dependencies": {
         "aws-sign2": {
           "version": "0.7.0",
-          "from": "aws-sign2@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
           "version": "1.6.0",
-          "from": "aws4@>=1.6.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
         },
         "caseless": {
           "version": "0.12.0",
-          "from": "caseless@>=0.12.0 <0.13.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          },
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
             }
           }
         },
         "extend": {
           "version": "3.0.1",
-          "from": "extend@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
           "version": "2.3.1",
-          "from": "form-data@>=2.3.1 <2.4.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          },
           "dependencies": {
             "asynckit": {
               "version": "0.4.0",
-              "from": "asynckit@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
             }
           }
         },
         "har-validator": {
           "version": "5.0.3",
-          "from": "har-validator@>=5.0.3 <5.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          },
           "dependencies": {
             "ajv": {
               "version": "5.5.2",
-              "from": "ajv@>=5.1.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              },
               "dependencies": {
                 "co": {
                   "version": "4.6.0",
-                  "from": "co@>=4.6.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                  "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
                 },
                 "fast-deep-equal": {
                   "version": "1.0.0",
-                  "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+                  "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
                 },
                 "fast-json-stable-stringify": {
                   "version": "2.0.0",
-                  "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+                  "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
                 },
                 "json-schema-traverse": {
                   "version": "0.3.1",
-                  "from": "json-schema-traverse@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
+                  "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                  "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
                 }
               }
             },
             "har-schema": {
               "version": "2.0.0",
-              "from": "har-schema@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+              "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
             }
           }
         },
         "hawk": {
           "version": "6.0.2",
-          "from": "hawk@>=6.0.2 <6.1.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
+          },
           "dependencies": {
-            "hoek": {
-              "version": "4.2.0",
-              "from": "hoek@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
-            },
             "boom": {
               "version": "4.3.1",
-              "from": "boom@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+              "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
             },
             "cryptiles": {
               "version": "3.1.2",
-              "from": "cryptiles@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+              "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+              "requires": {
+                "boom": "5.x.x"
+              },
               "dependencies": {
                 "boom": {
                   "version": "5.2.0",
-                  "from": "boom@>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                  "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                  "requires": {
+                    "hoek": "4.x.x"
+                  }
                 }
               }
             },
+            "hoek": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+              "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+            },
             "sntp": {
               "version": "2.1.0",
-              "from": "sntp@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+              "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+              "requires": {
+                "hoek": "4.x.x"
+              }
             }
           }
         },
         "http-signature": {
           "version": "1.2.0",
-          "from": "http-signature@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
             },
             "jsprim": {
               "version": "1.4.1",
-              "from": "jsprim@>=1.2.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+              "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              },
               "dependencies": {
                 "extsprintf": {
                   "version": "1.3.0",
-                  "from": "extsprintf@1.3.0",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                  "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
                 },
                 "json-schema": {
                   "version": "0.2.3",
-                  "from": "json-schema@0.2.3",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                  "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                 },
                 "verror": {
                   "version": "1.10.0",
-                  "from": "verror@1.10.0",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                  "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+                  "requires": {
+                    "assert-plus": "^1.0.0",
+                    "core-util-is": "1.0.2",
+                    "extsprintf": "^1.2.0"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     }
                   }
                 }
@@ -467,43 +673,69 @@
             },
             "sshpk": {
               "version": "1.13.1",
-              "from": "sshpk@>=1.7.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+              "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+              "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
+              },
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                },
-                "dashdash": {
-                  "version": "1.14.1",
-                  "from": "dashdash@>=1.12.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                },
-                "getpass": {
-                  "version": "0.1.7",
-                  "from": "getpass@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-                },
-                "jsbn": {
-                  "version": "0.1.1",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                },
-                "tweetnacl": {
-                  "version": "0.14.5",
-                  "from": "tweetnacl@>=0.14.0 <0.15.0",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                  "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.1",
-                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                  "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "^0.14.3"
+                  }
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                  "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                  "requires": {
+                    "assert-plus": "^1.0.0"
+                  }
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                  "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "~0.1.0"
+                  }
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                  "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                  "requires": {
+                    "assert-plus": "^1.0.0"
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                  "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                  "optional": true
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                  "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                  "optional": true
                 }
               }
             }
@@ -511,114 +743,156 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "mime-types": {
           "version": "2.1.17",
-          "from": "mime-types@>=2.1.17 <2.2.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "requires": {
+            "mime-db": "~1.30.0"
+          },
           "dependencies": {
             "mime-db": {
               "version": "1.30.0",
-              "from": "mime-db@>=1.30.0 <1.31.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+              "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
             }
           }
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.2 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "performance-now": {
           "version": "2.1.0",
-          "from": "performance-now@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "qs": {
           "version": "6.5.1",
-          "from": "qs@>=6.5.1 <6.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "from": "safe-buffer@>=5.1.1 <6.0.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
         },
         "tough-cookie": {
           "version": "2.3.3",
-          "from": "tough-cookie@>=2.3.3 <2.4.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "requires": {
+            "punycode": "^1.4.1"
+          },
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
-              "from": "punycode@>=1.4.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
             }
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "from": "tunnel-agent@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         },
         "uuid": {
           "version": "3.1.0",
-          "from": "uuid@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
     "sanitize-html": {
       "version": "1.16.3",
-      "from": "sanitize-html@>=1.14.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.16.3.tgz",
+      "integrity": "sha512-XpAJGnkMfNM7AzXLRw225blBB/pE4dM4jzRn98g4r88cfxwN6g+5IsRmCAh/gbhYGm6u6i97zsatMOM7Lr8wyw==",
+      "requires": {
+        "htmlparser2": "^3.9.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.mergewith": "^4.6.0",
+        "postcss": "^6.0.14",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
       "dependencies": {
         "htmlparser2": {
           "version": "3.9.2",
-          "from": "htmlparser2@>=3.9.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          },
           "dependencies": {
             "domelementtype": {
               "version": "1.3.0",
-              "from": "domelementtype@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
             },
             "domhandler": {
               "version": "2.4.1",
-              "from": "domhandler@>=2.3.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+              "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+              "requires": {
+                "domelementtype": "1"
+              }
             },
             "domutils": {
               "version": "1.6.2",
-              "from": "domutils@>=1.5.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
+              "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+              "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+              },
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+                  "requires": {
+                    "domelementtype": "~1.1.1",
+                    "entities": "~1.1.1"
+                  },
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.1.3",
-                      "from": "domelementtype@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
                     }
                   }
                 }
@@ -626,48 +900,60 @@
             },
             "entities": {
               "version": "1.1.1",
-              "from": "entities@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+              "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "readable-stream": {
               "version": "2.3.3",
-              "from": "readable-stream@>=2.0.2 <3.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                 },
                 "safe-buffer": {
                   "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.1 <5.2.0",
-                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                  "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
                 },
                 "string_decoder": {
                   "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                  "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             }
@@ -675,43 +961,59 @@
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "from": "lodash.clonedeep@>=4.5.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
         "lodash.escaperegexp": {
           "version": "4.1.2",
-          "from": "lodash.escaperegexp@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+          "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
         },
         "lodash.mergewith": {
           "version": "4.6.0",
-          "from": "lodash.mergewith@>=4.6.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+          "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
         },
         "postcss": {
           "version": "6.0.16",
-          "from": "postcss@>=6.0.14 <7.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "requires": {
+            "chalk": "^2.3.0",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.1.0"
+          },
           "dependencies": {
             "chalk": {
               "version": "2.3.0",
-              "from": "chalk@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.0",
-                  "from": "ansi-styles@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                  "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+                  "requires": {
+                    "color-convert": "^1.9.0"
+                  },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.1",
-                      "from": "color-convert@>=1.9.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+                      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+                      "requires": {
+                        "color-name": "^1.1.1"
+                      },
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.3",
-                          "from": "color-name@>=1.1.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
                         }
                       }
                     }
@@ -719,18 +1021,21 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                 },
                 "supports-color": {
                   "version": "4.5.0",
-                  "from": "supports-color@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+                  "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                  "requires": {
+                    "has-flag": "^2.0.0"
+                  },
                   "dependencies": {
                     "has-flag": {
                       "version": "2.0.0",
-                      "from": "has-flag@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                     }
                   }
                 }
@@ -738,18 +1043,21 @@
             },
             "source-map": {
               "version": "0.6.1",
-              "from": "source-map@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
               "version": "5.1.0",
-              "from": "supports-color@>=5.1.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+              "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+              "requires": {
+                "has-flag": "^2.0.0"
+              },
               "dependencies": {
                 "has-flag": {
                   "version": "2.0.0",
-                  "from": "has-flag@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                  "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 }
               }
             }
@@ -757,62 +1065,96 @@
         },
         "srcset": {
           "version": "1.0.0",
-          "from": "srcset@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+          "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+          "requires": {
+            "array-uniq": "^1.0.2",
+            "number-is-nan": "^1.0.0"
+          },
           "dependencies": {
             "array-uniq": {
               "version": "1.0.3",
-              "from": "array-uniq@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "from": "number-is-nan@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
             }
           }
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
     "showdown": {
       "version": "1.8.6",
-      "from": "showdown@>=1.7.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
+      "integrity": "sha1-kepO47elRIqspoIKTifmkMatdxw=",
+      "requires": {
+        "yargs": "^10.0.3"
+      },
       "dependencies": {
         "yargs": {
           "version": "10.0.3",
-          "from": "yargs@>=10.0.3 <11.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.0.0"
+          },
           "dependencies": {
             "cliui": {
               "version": "3.2.0",
-              "from": "cliui@>=3.2.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "from": "string-width@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  },
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "requires": {
+                        "number-is-nan": "^1.0.0"
+                      },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                         }
                       }
                     }
@@ -820,52 +1162,72 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "2.1.0",
-                  "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                  "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                  "requires": {
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1"
+                  }
                 }
               }
             },
             "decamelize": {
               "version": "1.2.0",
-              "from": "decamelize@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
             },
             "find-up": {
               "version": "2.1.0",
-              "from": "find-up@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "requires": {
+                "locate-path": "^2.0.0"
+              },
               "dependencies": {
                 "locate-path": {
                   "version": "2.0.0",
-                  "from": "locate-path@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                  "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                  "requires": {
+                    "p-locate": "^2.0.0",
+                    "path-exists": "^3.0.0"
+                  },
                   "dependencies": {
                     "p-locate": {
                       "version": "2.0.0",
-                      "from": "p-locate@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                      "requires": {
+                        "p-limit": "^1.1.0"
+                      },
                       "dependencies": {
                         "p-limit": {
                           "version": "1.2.0",
-                          "from": "p-limit@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+                          "requires": {
+                            "p-try": "^1.0.0"
+                          },
                           "dependencies": {
                             "p-try": {
                               "version": "1.0.0",
-                              "from": "p-try@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
                             }
                           }
                         }
@@ -873,8 +1235,8 @@
                     },
                     "path-exists": {
                       "version": "3.0.0",
-                      "from": "path-exists@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                     }
                   }
                 }
@@ -882,62 +1244,91 @@
             },
             "get-caller-file": {
               "version": "1.0.2",
-              "from": "get-caller-file@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+              "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
             },
             "os-locale": {
               "version": "2.1.0",
-              "from": "os-locale@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+              "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              },
               "dependencies": {
                 "execa": {
                   "version": "0.7.0",
-                  "from": "execa@>=0.7.0 <0.8.0",
                   "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                  "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                  "requires": {
+                    "cross-spawn": "^5.0.1",
+                    "get-stream": "^3.0.0",
+                    "is-stream": "^1.1.0",
+                    "npm-run-path": "^2.0.0",
+                    "p-finally": "^1.0.0",
+                    "signal-exit": "^3.0.0",
+                    "strip-eof": "^1.0.0"
+                  },
                   "dependencies": {
                     "cross-spawn": {
                       "version": "5.1.0",
-                      "from": "cross-spawn@>=5.0.1 <6.0.0",
                       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                      "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                      },
                       "dependencies": {
                         "lru-cache": {
                           "version": "4.1.1",
-                          "from": "lru-cache@>=4.0.1 <5.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+                          "requires": {
+                            "pseudomap": "^1.0.2",
+                            "yallist": "^2.1.2"
+                          },
                           "dependencies": {
                             "pseudomap": {
                               "version": "1.0.2",
-                              "from": "pseudomap@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
                             },
                             "yallist": {
                               "version": "2.1.2",
-                              "from": "yallist@>=2.1.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
                             }
                           }
                         },
                         "shebang-command": {
                           "version": "1.2.0",
-                          "from": "shebang-command@>=1.2.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                          "requires": {
+                            "shebang-regex": "^1.0.0"
+                          },
                           "dependencies": {
                             "shebang-regex": {
                               "version": "1.0.0",
-                              "from": "shebang-regex@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
                             }
                           }
                         },
                         "which": {
                           "version": "1.3.0",
-                          "from": "which@>=1.2.9 <2.0.0",
                           "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+                          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+                          "requires": {
+                            "isexe": "^2.0.0"
+                          },
                           "dependencies": {
                             "isexe": {
                               "version": "2.0.0",
-                              "from": "isexe@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
                             }
                           }
                         }
@@ -945,64 +1336,73 @@
                     },
                     "get-stream": {
                       "version": "3.0.0",
-                      "from": "get-stream@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
                     },
                     "is-stream": {
                       "version": "1.1.0",
-                      "from": "is-stream@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
                     },
                     "npm-run-path": {
                       "version": "2.0.2",
-                      "from": "npm-run-path@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                      "requires": {
+                        "path-key": "^2.0.0"
+                      },
                       "dependencies": {
                         "path-key": {
                           "version": "2.0.1",
-                          "from": "path-key@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
                         }
                       }
                     },
                     "p-finally": {
                       "version": "1.0.0",
-                      "from": "p-finally@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
                     },
                     "signal-exit": {
                       "version": "3.0.2",
-                      "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
                     },
                     "strip-eof": {
                       "version": "1.0.0",
-                      "from": "strip-eof@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
                     }
                   }
                 },
                 "lcid": {
                   "version": "1.0.0",
-                  "from": "lcid@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                  "requires": {
+                    "invert-kv": "^1.0.0"
+                  },
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
-                      "from": "invert-kv@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
                     }
                   }
                 },
                 "mem": {
                   "version": "1.1.0",
-                  "from": "mem@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                  "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+                  "requires": {
+                    "mimic-fn": "^1.0.0"
+                  },
                   "dependencies": {
                     "mimic-fn": {
                       "version": "1.1.0",
-                      "from": "mimic-fn@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
                     }
                   }
                 }
@@ -1010,38 +1410,45 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "from": "require-directory@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "from": "require-main-filename@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
             },
             "set-blocking": {
               "version": "2.0.0",
-              "from": "set-blocking@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
             },
             "string-width": {
               "version": "2.1.1",
-              "from": "string-width@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              },
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "2.0.0",
-                  "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
                 },
                 "strip-ansi": {
                   "version": "4.0.0",
-                  "from": "strip-ansi@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                  "requires": {
+                    "ansi-regex": "^3.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "3.0.0",
-                      "from": "ansi-regex@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
                     }
                   }
                 }
@@ -1049,23 +1456,26 @@
             },
             "which-module": {
               "version": "2.0.0",
-              "from": "which-module@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
             },
             "y18n": {
               "version": "3.2.1",
-              "from": "y18n@>=3.2.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
             },
             "yargs-parser": {
               "version": "8.1.0",
-              "from": "yargs-parser@>=8.0.0 <9.0.0",
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+              "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+              "requires": {
+                "camelcase": "^4.1.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
-                  "from": "camelcase@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                 }
               }
             }
@@ -1075,32 +1485,37 @@
     },
     "showdown-htmlescape": {
       "version": "0.1.9",
-      "from": "showdown-htmlescape@>=0.1.9 <0.2.0",
-      "resolved": "https://registry.npmjs.org/showdown-htmlescape/-/showdown-htmlescape-0.1.9.tgz"
-    },
-    "slack-utils": {
-      "version": "0.3.2",
-      "from": "slack-utils@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/slack-utils/-/slack-utils-0.3.2.tgz",
-      "dependencies": {
-        "ws": {
-          "version": "0.7.2",
-          "from": "ws@>=0.7.1 <0.8.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
-          "dependencies": {
-            "options": {
-              "version": "0.0.6",
-              "from": "options@>=0.0.5",
-              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-            },
-            "ultron": {
-              "version": "1.0.2",
-              "from": "ultron@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-            }
-          }
-        }
+      "resolved": "https://registry.npmjs.org/showdown-htmlescape/-/showdown-htmlescape-0.1.9.tgz",
+      "integrity": "sha512-kkg0Lh6CRzJKMvIkNBYNkZaJiZSii98mfiZj3FpQK0lXn1iV0UT5VD63YoTAqOCP7QiIo3nTH/z5ndVKCfMenQ==",
+      "requires": {
+        "showdown": "^1.2.3"
       }
+    },
+    "slack": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/slack/-/slack-11.0.2.tgz",
+      "integrity": "sha512-rv842+S+AGyZCmMMd8xPtW5DvJ9LzWTAKfxi8Gw57oYlXgcKtFuHd4nqk6lTPpRKdUGn3tx/Drd0rjQR3dQPqw==",
+      "requires": {
+        "tiny-json-http": "^7.0.2"
+      }
+    },
+    "tiny-json-http": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.3.0.tgz",
+      "integrity": "sha512-dZrf9ZGZQhe8QhhPN3o4uDCQuBc3Gaq4CtbU/67hQDWXuvjLI1mayr8AOFSiUGa3F818SpIgUnC3mM673VRHGQ=="
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    },
+    "ws": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "sanitize-html": "^1.14.1",
     "showdown": "^1.7.6",
     "showdown-htmlescape": "^0.1.9",
-    "slack-utils": "^0.3.2"
+    "slack": "11.0.2",
+    "ws": "^7.4.4"
   },
   "engines": {
-    "node": "4.8.5"
+    "node": "10.19.0"
   }
 }

--- a/presence.coffee
+++ b/presence.coffee
@@ -1,21 +1,83 @@
-rtm = require('slack-utils/rtm')(process.env.API_TOKEN)
+slack = require('slack')
+
 EventEmitter = require('events').EventEmitter
-presence = new EventEmitter
 online = []
+
+
+WebSocket = require('ws')
+presence = new EventEmitter
+slackData = {}
+
+#parses an RTM event
+
+parseMessage = (msg) ->
+  msg = JSON.parse(msg)
+  #we are only interested in presence change
+  if msg.type == 'presence_change'
+    sendPresenceEvent msg
+  else if msg.type == 'hello'
+    presence.emit 'ready'
+  else
+    presence.emit msg.type, msg
+  presence.emit '*', msg
+  return
+
+#translates a slack unique userid to readable username
+
+userIdToNick = (userid) ->
+  users = slackData.users
+  for user in users
+    if user.id == userid
+      return user.name
+  'unknown'
+
+#throw the initial data to the database
+#via the events
+
+sendPresenceEvent = (msg) ->
+  for user in msg["users"]
+  #ignore the slackbot
+    if user.id != 'USLACKBOT'
+      presence.emit msg.presence, userIdToNick user
+  return
+
+getPresenceSubscriptionJson = (users) ->
+  JSON.stringify
+    type: "presence_sub"
+    ids: users.map (user) -> user.id
+
 
 presence.online = ()->
   online
 
-rtm.on 'active', (username)->
+presence.on 'active', (username)->
   online.push username if username not in online
   presence.emit 'change'
 
-rtm.on 'away', (username)->
+presence.on 'away', (username)->
   index = online.indexOf username
   online.splice index, 1 if index > -1
   presence.emit 'change'
 
-rtm.on 'ready', ()->
+presence.on 'ready', ()->
   console.log "Connected to Slack RTM API"
 
-module.exports = presence
+module.exports = (token) ->
+#First call the presence.start method of Slack API
+  slack.rtm.start ({token: token, batch_presence_aware: 1})
+    .then (res) ->
+      #This is the initial response data with a lot of interesting keys
+      #So we store it as well
+      slackData = res
+      #Connect the websocket
+      ws = new WebSocket(res.url)
+      #Sets up the callback for websocket messaging
+      ws.on 'message', parseMessage
+      ws.on 'open', (socket)->
+        presence.emit 'connect'
+      ws.on 'error', (err)->
+        presence.emit 'error', err
+      presence.on 'ready', () ->
+        ws.send getPresenceSubscriptionJson res.users
+  #Return the eventemitter
+  return presence

--- a/slack_utils.coffee
+++ b/slack_utils.coffee
@@ -1,0 +1,80 @@
+slack = require('slack')
+
+listToHash = (list, keyName, innerKey)->
+  list = list[keyName]
+  hash = {}
+  for item in list
+    if innerKey?
+      hash[item.id] = item[innerKey]
+    else
+      hash[item.id] = item
+  hash
+
+data = {}
+
+getUsers = (token)->
+  slack.users.list(token: token)
+    .then (res) ->
+      if res.ok
+          data['users.simple'] = listToHash res, "members", "name"
+          data['users'] = listToHash res, "members"
+
+getChannels = (token)->
+  slack.conversations.list (token: token)
+    .then (res) ->
+      if res.ok
+        data['channels.simple'] = listToHash res, "channels", "name"
+        data['channels'] = listToHash res, "channels"
+
+module.exports = (API_TOKEN, HOOK_URL)->
+  if API_TOKEN?
+    getUsers(API_TOKEN)
+    getChannels(API_TOKEN)
+
+  postMessage: (message, channel, nick, icon)->
+    messageData =
+      token: API_TOKEN
+      text: message
+      parse: "full"
+      as_user: false
+
+    if icon? and (icon[0..7] == 'https://' or icon[0..6] == 'http://')
+      messageData.icon_url=icon
+    # If icon is present and is not an emoji
+    else if icon? and not icon.match /^\:\w*\:$/
+      messageData.icon_emoji=":#{icon}:"
+    # If icon is present and is an emoji
+    else if icon? and icon.match /^\:\w*\:$/
+      messageData.icon_emoji="#{icon}"
+    if channel?
+      messageData.channel = "##{channel}"
+    if nick?
+      messageData.username="#{nick}"
+
+    slack.chat.postMessage(messageData)
+  # exporting this to test the method
+  listToHash: listToHash
+  parseMessage: (message)->
+    message
+      .replace("<!channel>", "@channel")
+      .replace("<!group>", "@group")
+      .replace("<!everyone>", "@everyone")
+      .replace /<#(C\w*)>/g, (match, channelId)->
+        "##{data['channels.simple'][channelId]}"
+      .replace /<@(U\w*)>/g, (match, userId)->
+        "@#{data['users.simple'][userId]}"
+      .replace /<(\S*)>/g, (match, link)->
+        link
+      .replace /http(s)?:\/\/([^\s]*)\|([^\s]*)/g, (match, protocol, href1, href2) ->
+        return ("http" + (protocol || "") + "://" + href1) if href1 == href2
+      .replace /&amp;/g, "&"
+      .replace /&lt;/g, "<"
+      .replace /&gt;/g, ">"
+
+  userInfoById: (search_id)->
+    for id, info of data['users']
+      return info if search_id == id
+
+  userInfoByName: (username)->
+    for id, info of data['users']
+      return info if info['name'] == username


### PR DESCRIPTION
From the discussion https://github.com/sdslabs/jinora/issues/71, 
- `slack-utils` uses deprecated API calls and is not maintained

This PR
- pulls essential code from the package and adds it locally for easy maintenance.
- Uses [slack](https://www.npmjs.com/package/slack) as a dependency instead of directly calling APIs.
- Updates packages to support changes.